### PR TITLE
Add sleek pre-commit hook for formatting SQL

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,5 @@
+- id: sleek-format
+  name: Format SQL with sleek
+  entry: sleek
+  language: rust
+  types: [sql]


### PR DESCRIPTION
A [pre-commit](https://pre-commit.com/) hook is really useful for
ensuring formatting, linting, etc for changes in repos. Adding this hook
would be really useful in configuring more projects to use sleek!

Kudos for the very useful tool -- my SQL formatter of choice!